### PR TITLE
SuggestionAction added and SuggestionState fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## [0.5.6] - 26 September 2021
+- adds `suggestionAction` to change focus on suggestion tap
+- suggestions now always show on `SuggestionState.enabled`
+
 ## [0.5.5] - 03 September 2021
-- adds `searchInputaction` property to focus to next input
+- adds `searchInputAction` property to focus to next input
 
 ## [0.5.4] - 01 September 2021
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [searchfield: ^0.5.5](https://pub.dev/packages/searchfield)
+# [searchfield: ^0.5.6](https://pub.dev/packages/searchfield)
 
 A highly customizable simple and easy to use flutter Widget to add a searchfield to your Flutter Application.This Widget allows you to search and select from list of suggestions.
 
@@ -117,7 +117,7 @@ Form(
 - `controller`: TextEditing Controller to interact with the searchfield.
 - `suggestions` : list of Strings to search from.**(Mandatory)**.
 - `SuggestionState`: enum to hide/show the suggestion on focusing the searchfield defaults to `SuggestionState.hidden`. 
-- `searchActionType` : An action the user has requested the text input control to perform throgh the submit button on keyboard.          
+- `textInputAction` : An action the user has requested the text input control to perform throgh the submit button on keyboard.          
 - `initialValue` : The initial value to be set in searchfield when its rendered, if not specified it will be empty.
 - `hasOverlay` : shows floating suggestions on top of the Ui
   if disabled the suggestions will be shown along the searchInput. if not specified defaults to `true`.
@@ -131,6 +131,7 @@ Form(
 - `itemHeight` : height of each suggestion Item, (defaults to 35.0).
 - `marginColor` : Color for the margin between the suggestions.
 - `maxSuggestionsInViewPort` : The max number of suggestions that can be shown in a viewport.
+- `SuggestionAction` : enum to control focus of the searchfield on suggestion tap
 
 ### You can find all the [code samples here](https://github.com/maheshmnj/searchfield/example)
 

--- a/example/lib/example2.dart
+++ b/example/lib/example2.dart
@@ -62,6 +62,8 @@ class _ExampleDemoState extends State<ExampleDemo> {
           Padding(
             padding: const EdgeInsets.all(8.0),
             child: SearchField(
+              suggestionState: SuggestionState.enabled,
+              suggestionAction: SuggestionAction.shift,
               suggestions: _suggestions,
               searchInputAction: TextInputAction.next,
               controller: _searchController,
@@ -83,6 +85,8 @@ class _ExampleDemoState extends State<ExampleDemo> {
               key: _formKey,
               child: SearchField(
                 suggestions: _statesOfIndia,
+                suggestionState: SuggestionState.enabled,
+                searchInputAction: TextInputAction.next,
                 hint: 'SearchField Sample 2',
                 searchStyle: TextStyle(
                   fontSize: 18,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/country_model.dart';
+import 'package:example/example2.dart';
 import 'package:flutter/material.dart';
 import 'package:searchfield/searchfield.dart';
 
@@ -15,9 +16,7 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: MyHomePage(
-        title: "Demo Home Page",
-      ),
+      home: ExampleDemo(),
     );
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:example/country_model.dart';
-import 'package:example/example2.dart';
 import 'package:flutter/material.dart';
 import 'package:searchfield/searchfield.dart';
 
@@ -16,7 +15,9 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: ExampleDemo(),
+      home: MyHomePage(
+        title: "Demo Home Page",
+      ),
     );
   }
 }

--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -7,6 +7,9 @@ enum SuggestionState {
 
   /// hide the suggestions on initial focus
   hidden,
+
+  /// show suggestions only on tap
+  onTap,
 }
 
 enum SuggestionAction {
@@ -200,22 +203,26 @@ class _SearchFieldState extends State<SearchField> {
       });
       if (widget.hasOverlay) {
         if (sourceFocused) {
-          // if (widget.suggestionState == SuggestionState.enabled) {
-          //   Future.delayed(Duration(milliseconds: 100), () {
-          //     sourceStream.sink.add(widget.suggestions);
-          //   });
-          // }
+          if (widget.initialValue == null) {
+            if (widget.suggestionState == SuggestionState.enabled) {
+              Future.delayed(Duration(milliseconds: 100), () {
+                sourceStream.sink.add(widget.suggestions);
+              });
+            }
+          }
           _overlayEntry = _createOverlay();
           Overlay.of(context)!.insert(_overlayEntry);
         } else {
           _overlayEntry.remove();
         }
       } else if (sourceFocused) {
-        // if (widget.suggestionState == SuggestionState.enabled) {
-        //   Future.delayed(Duration(milliseconds: 100), () {
-        //     sourceStream.sink.add(widget.suggestions);
-        //   });
-        // }
+        if (widget.initialValue == null) {
+          if (widget.suggestionState == SuggestionState.enabled) {
+            Future.delayed(Duration(milliseconds: 100), () {
+              sourceStream.sink.add(widget.suggestions);
+            });
+          }
+        }
       }
     });
   }
@@ -416,22 +423,23 @@ class _SearchFieldState extends State<SearchField> {
         CompositedTransformTarget(
           link: _layerLink,
           child: TextFormField(
+            onTap: () {
+              /// only call that if [SuggestionState.onTap] is selected
+              if (!sourceFocused &&
+                  widget.suggestionState == SuggestionState.onTap) {
+                setState(() {
+                  sourceFocused = true;
+                });
+                Future.delayed(Duration(milliseconds: 100), () {
+                  sourceStream.sink.add(widget.suggestions);
+                });
+              }
+            },
             controller: widget.controller ?? sourceController,
             focusNode: _focus,
             validator: widget.validator,
             style: widget.searchStyle,
             textInputAction: widget.searchInputAction,
-            onTap: () {
-              // if (!sourceFocused &&
-              //     widget.suggestionState == SuggestionState.enabled) {
-              //   setState(() {
-              //     sourceFocused = true;
-              //   });
-              //   Future.delayed(Duration(milliseconds: 100), () {
-              //     sourceStream.sink.add(widget.suggestions);
-              //   });
-              // }
-            },
             decoration:
                 widget.searchInputDecoration?.copyWith(hintText: widget.hint) ??
                     InputDecoration(hintText: widget.hint),

--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -9,6 +9,14 @@ enum SuggestionState {
   hidden,
 }
 
+enum SuggestionAction {
+  /// shift to next focus
+  shift,
+
+  /// close keyboard and unfocus
+  unfocus,
+}
+
 class SearchField extends StatefulWidget {
   /// Data source to perform search.
   final List<String> suggestions;
@@ -42,6 +50,9 @@ class SearchField extends StatefulWidget {
 
   /// defaults to SuggestionState.hidden
   final SuggestionState suggestionState;
+
+  /// Specifies whether the [searchInputAction] should directly be called on suggestion selection
+  final SuggestionAction? suggestionAction;
 
   /// Specifies [BoxDecoration] for suggestion list. The property can be used to add [BoxShadow],
   /// and much more. For more information, checkout [BoxDecoration].
@@ -157,6 +168,7 @@ class SearchField extends StatefulWidget {
     this.maxSuggestionsInViewPort = 5,
     this.onTap,
     this.searchInputAction,
+    this.suggestionAction,
   })  : assert(
             (initialValue != null && suggestions.contains(initialValue)) ||
                 initialValue == null,
@@ -188,11 +200,22 @@ class _SearchFieldState extends State<SearchField> {
       });
       if (widget.hasOverlay) {
         if (sourceFocused) {
+          // if (widget.suggestionState == SuggestionState.enabled) {
+          //   Future.delayed(Duration(milliseconds: 100), () {
+          //     sourceStream.sink.add(widget.suggestions);
+          //   });
+          // }
           _overlayEntry = _createOverlay();
           Overlay.of(context)!.insert(_overlayEntry);
         } else {
           _overlayEntry.remove();
         }
+      } else if (sourceFocused) {
+        // if (widget.suggestionState == SuggestionState.enabled) {
+        //   Future.delayed(Duration(milliseconds: 100), () {
+        //     sourceStream.sink.add(widget.suggestions);
+        //   });
+        // }
       }
     });
   }
@@ -282,6 +305,17 @@ class _SearchFieldState extends State<SearchField> {
                       offset: sourceController!.text.length,
                     ),
                   );
+
+                  // suggestion action
+                  if (widget.suggestionAction != null) {
+                    if (widget.suggestionAction == SuggestionAction.shift) {
+                      _focus.nextFocus();
+                    } else if (widget.suggestionAction ==
+                        SuggestionAction.unfocus) {
+                      _focus.unfocus();
+                    }
+                  }
+
                   // hide the suggestions
                   sourceStream.sink.add(null);
                   if (widget.onTap != null) {
@@ -388,15 +422,15 @@ class _SearchFieldState extends State<SearchField> {
             style: widget.searchStyle,
             textInputAction: widget.searchInputAction,
             onTap: () {
-              if (!sourceFocused &&
-                  widget.suggestionState == SuggestionState.enabled) {
-                setState(() {
-                  sourceFocused = true;
-                });
-                Future.delayed(Duration(milliseconds: 100), () {
-                  sourceStream.sink.add(widget.suggestions);
-                });
-              }
+              // if (!sourceFocused &&
+              //     widget.suggestionState == SuggestionState.enabled) {
+              //   setState(() {
+              //     sourceFocused = true;
+              //   });
+              //   Future.delayed(Duration(milliseconds: 100), () {
+              //     sourceStream.sink.add(widget.suggestions);
+              //   });
+              // }
             },
             decoration:
                 widget.searchInputDecoration?.copyWith(hintText: widget.hint) ??

--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -54,7 +54,7 @@ class SearchField extends StatefulWidget {
   /// defaults to SuggestionState.hidden
   final SuggestionState suggestionState;
 
-  /// Specifies whether the [searchInputAction] should directly be called on suggestion selection
+  /// Specifies the [searchInputAction]  called on suggestion tap.
   final SuggestionAction? suggestionAction;
 
   /// Specifies [BoxDecoration] for suggestion list. The property can be used to add [BoxShadow],

--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -12,6 +12,7 @@ enum SuggestionState {
   onTap,
 }
 
+// enum to define the Focus of the searchfield when a suggestion is tapped
 enum SuggestionAction {
   /// shift to next focus
   shift,

--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -15,7 +15,7 @@ enum SuggestionState {
 // enum to define the Focus of the searchfield when a suggestion is tapped
 enum SuggestionAction {
   /// shift to next focus
-  shift,
+  next,
 
   /// close keyboard and unfocus
   unfocus,
@@ -32,7 +32,7 @@ class SearchField extends StatefulWidget {
   final String? hint;
 
   /// Define a [TextInputAction] that is called when the field is submitted
-  final TextInputAction? searchInputAction;
+  final TextInputAction? textInputAction;
 
   /// The initial value to be selected for [SearchField]. The value
   /// must be present in [suggestions].
@@ -55,7 +55,7 @@ class SearchField extends StatefulWidget {
   /// defaults to SuggestionState.hidden
   final SuggestionState suggestionState;
 
-  /// Specifies the [searchInputAction]  called on suggestion tap.
+  /// Specifies the [SuggestionAction] called on suggestion tap.
   final SuggestionAction? suggestionAction;
 
   /// Specifies [BoxDecoration] for suggestion list. The property can be used to add [BoxShadow],
@@ -171,7 +171,7 @@ class SearchField extends StatefulWidget {
     this.suggestionItemDecoration,
     this.maxSuggestionsInViewPort = 5,
     this.onTap,
-    this.searchInputAction,
+    this.textInputAction,
     this.suggestionAction,
   })  : assert(
             (initialValue != null && suggestions.contains(initialValue)) ||
@@ -316,7 +316,7 @@ class _SearchFieldState extends State<SearchField> {
 
                   // suggestion action
                   if (widget.suggestionAction != null) {
-                    if (widget.suggestionAction == SuggestionAction.shift) {
+                    if (widget.suggestionAction == SuggestionAction.next) {
                       _focus.nextFocus();
                     } else if (widget.suggestionAction ==
                         SuggestionAction.unfocus) {
@@ -440,7 +440,7 @@ class _SearchFieldState extends State<SearchField> {
             focusNode: _focus,
             validator: widget.validator,
             style: widget.searchStyle,
-            textInputAction: widget.searchInputAction,
+            textInputAction: widget.textInputAction,
             decoration:
                 widget.searchInputDecoration?.copyWith(hintText: widget.hint) ??
                     InputDecoration(hintText: widget.hint),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: searchfield
 description: A highly customizable simple and easy to use flutter Widget to add a searchfield to your Flutter Application.This Widget allows you to search and select from list of suggestions.
-version: 0.5.5
+version: 0.5.6
 homepage: https://github.com/maheshmnj/searchfield
 
 environment:


### PR DESCRIPTION
Functionalities added:

- SuggestionAction: the action called when the user taps on a suggestion.
    - `shift`: automatically shift to next focusnode.
    - `unfocus`: automatically closekeyboard and lose focus-
- SuggestionState: Added `onTap` and improved `enabled`.
    - `onTap` only shows the suggestions when the user manually taps on the searchfield.
    - `enabled` now always shows the suggestions, even when the focus was automatically shifted.