### PR TITLE
Fix - Unhandled Exception: Bad state: Cannot add new events after cal…

### DIFF
--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -340,13 +340,15 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
     searchController = widget.controller ?? TextEditingController();
     initialize();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _overlayEntry = _createOverlay();
-      if (widget.initialValue == null ||
-          widget.initialValue!.searchKey.isEmpty) {
-        suggestionStream.sink.add(null);
-      } else {
-        searchController!.text = widget.initialValue!.searchKey;
-        suggestionStream.sink.add([widget.initialValue]);
+      if (mounted) {
+        _overlayEntry = _createOverlay();
+        if (widget.initialValue == null ||
+            widget.initialValue!.searchKey.isEmpty) {
+          suggestionStream.sink.add(null);
+        } else {
+          searchController!.text = widget.initialValue!.searchKey;
+          suggestionStream.sink.add([widget.initialValue]);
+        }
       }
     });
   }


### PR DESCRIPTION
If applied this pull request will fix the "Unhandled Exception: Bad state: Cannot add new events after calling close".

At some point, addPostFrameCallback was being called when the component was already disassembled, causing the application to crash.

Issue: https://github.com/maheshmnj/searchfield/issues/43

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing using `flutter test`

If you need help, consider pinging the maintainer @maheshmnj

<!-- Links -->
[Contributor Guide]: https://github.com/maheshmnj/searchfield/blob/master/CONTRIBUTING.md