### PR TITLE
Add custom comparator function option

### DIFF
--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -235,10 +234,11 @@ class SearchField<T> extends StatefulWidget {
   /// defaults to [SizedBox.shrink]
   final Widget emptyWidget;
 
-  /// if true diacritics are ignored, this means:
-  /// if café is in suggestion list, search for cafe will suggest also café
-  /// and viceversa
-  final bool ignoreDiacritics;
+  /// Function that implements the comparison criteria,
+  /// the 2 parameters are the input text and each suggestion and 
+  /// should return true or false if the list should shown the suggestionKey
+  /// suggestion when the inputText is typed in the text field
+  final bool Function(String inputText, String suggestionKey)? comparator;
 
   /// Defines whether to enable autoCorrect defaults to `true`
   final bool autoCorrect;
@@ -282,7 +282,7 @@ class SearchField<T> extends StatefulWidget {
     this.suggestionAction,
     this.textInputAction,
     this.validator,
-    this.ignoreDiacritics = false
+    this.comparator
   })  : assert(
             (initialValue != null &&
                     suggestions.containsObject(initialValue)) ||
@@ -639,13 +639,13 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
                 return;
               }
               for (final suggestion in widget.suggestions) {
-                if (suggestion.searchKey
+                if (widget.comparator != null) {
+                  if (widget.comparator!(query, suggestion.searchKey)) {
+                    searchResult.add(suggestion);
+                  }
+                } else if (suggestion.searchKey
                     .toLowerCase()
                     .contains(query.toLowerCase())) {
-                  searchResult.add(suggestion);
-                } else if (widget.ignoreDiacritics && 
-                    removeDiacritics(suggestion.searchKey.toLowerCase())
-                    .contains(removeDiacritics(query.toLowerCase()))) {
                   searchResult.add(suggestion);
                 }
               }

--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -234,6 +235,11 @@ class SearchField<T> extends StatefulWidget {
   /// defaults to [SizedBox.shrink]
   final Widget emptyWidget;
 
+  /// if true diacritics are ignored, this means:
+  /// if café is in suggestion list, search for cafe will suggest also café
+  /// and viceversa
+  final bool ignoreDiacritics;
+
   /// Defines whether to enable autoCorrect defaults to `true`
   final bool autoCorrect;
 
@@ -276,6 +282,7 @@ class SearchField<T> extends StatefulWidget {
     this.suggestionAction,
     this.textInputAction,
     this.validator,
+    this.ignoreDiacritics = false
   })  : assert(
             (initialValue != null &&
                     suggestions.containsObject(initialValue)) ||
@@ -635,6 +642,10 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
                 if (suggestion.searchKey
                     .toLowerCase()
                     .contains(query.toLowerCase())) {
+                  searchResult.add(suggestion);
+                } else if (widget.ignoreDiacritics && 
+                    removeDiacritics(suggestion.searchKey.toLowerCase())
+                    .contains(removeDiacritics(query.toLowerCase()))) {
                   searchResult.add(suggestion);
                 }
               }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  diacritic: ^0.1.3
   flutter:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  diacritic: ^0.1.3
   flutter:
     sdk: flutter
 

--- a/test/searchfield_test.dart
+++ b/test/searchfield_test.dart
@@ -543,4 +543,69 @@ void main() {
     await tester.pumpAndSettle();
     expect(listFinder, findsNothing);
   });
+
+  testWidgets('Searchfield should not find suggestion with diacritics',
+        (WidgetTester tester) async {
+      final controller = TextEditingController();
+      await tester.pumpWidget(_boilerplate(
+          child: SearchField(
+        key: const Key('searchfield'),
+        suggestions: ['ABC', 'DÉF', 'GHI', 'JKL']
+            .map((e) => SearchFieldListItem<String>(e))
+            .toList(),
+        controller: controller,
+        suggestionState: Suggestion.expand,
+      )));
+      final listFinder = find.byType(ListView);
+      final textField = find.byType(TextFormField);
+      expect(textField, findsOneWidget);
+      expect(listFinder, findsNothing);
+      await tester.tap(textField);
+      await tester.enterText(textField, 'A');
+      await tester.pumpAndSettle();
+      expect(listFinder, findsOneWidget);
+      expect(find.text('ABC'), findsOneWidget);
+      expect(listFinder.evaluate().length, 1);
+      await tester.enterText(textField, 'DÉ');
+      await tester.pumpAndSettle();
+      expect(listFinder, findsOneWidget);
+      expect(find.text('DÉF'), findsOneWidget);
+      expect(listFinder.evaluate().length, 1);
+      await tester.enterText(textField, 'Á');
+      await tester.pumpAndSettle();
+      expect(listFinder, findsNothing);
+      await tester.enterText(textField, 'DE');
+      await tester.pumpAndSettle();
+      expect(listFinder, findsNothing);
+    });
+
+    testWidgets('Searchfield should find suggestion ignoring diacritics',
+        (WidgetTester tester) async {
+      final controller = TextEditingController();
+      await tester.pumpWidget(_boilerplate(
+          child: SearchField(
+        key: const Key('searchfield'),
+        ignoreDiacritics: true,
+        suggestions: ['ABC', 'DÉF', 'GHI', 'JKL']
+            .map((e) => SearchFieldListItem<String>(e))
+            .toList(),
+        controller: controller,
+        suggestionState: Suggestion.expand,
+      )));
+      final listFinder = find.byType(ListView);
+      final textField = find.byType(TextFormField);
+      expect(textField, findsOneWidget);
+      expect(listFinder, findsNothing);
+      await tester.tap(textField);
+      await tester.enterText(textField, 'Á');
+      await tester.pumpAndSettle();
+      expect(listFinder, findsOneWidget);
+      expect(find.text('ABC'), findsOneWidget);
+      expect(listFinder.evaluate().length, 1);
+      await tester.enterText(textField, 'DE');
+      await tester.pumpAndSettle();
+      expect(listFinder, findsOneWidget);
+      expect(find.text('DÉF'), findsOneWidget);
+      expect(listFinder.evaluate().length, 1);
+    });
 }

--- a/test/searchfield_test.dart
+++ b/test/searchfield_test.dart
@@ -544,13 +544,13 @@ void main() {
     expect(listFinder, findsNothing);
   });
 
-  testWidgets('Searchfield should not find suggestion with diacritics',
+  testWidgets('Searchfield should not find suggestion when typed reversed for default',
         (WidgetTester tester) async {
       final controller = TextEditingController();
       await tester.pumpWidget(_boilerplate(
           child: SearchField(
         key: const Key('searchfield'),
-        suggestions: ['ABC', 'DÉF', 'GHI', 'JKL']
+        suggestions: ['ABC', 'DEF', 'GHI', 'JKL']
             .map((e) => SearchFieldListItem<String>(e))
             .toList(),
         controller: controller,
@@ -561,32 +561,24 @@ void main() {
       expect(textField, findsOneWidget);
       expect(listFinder, findsNothing);
       await tester.tap(textField);
-      await tester.enterText(textField, 'A');
+      await tester.enterText(textField, 'AB');
       await tester.pumpAndSettle();
       expect(listFinder, findsOneWidget);
       expect(find.text('ABC'), findsOneWidget);
       expect(listFinder.evaluate().length, 1);
-      await tester.enterText(textField, 'DÉ');
-      await tester.pumpAndSettle();
-      expect(listFinder, findsOneWidget);
-      expect(find.text('DÉF'), findsOneWidget);
-      expect(listFinder.evaluate().length, 1);
-      await tester.enterText(textField, 'Á');
-      await tester.pumpAndSettle();
-      expect(listFinder, findsNothing);
-      await tester.enterText(textField, 'DE');
+      await tester.enterText(textField, 'BA');
       await tester.pumpAndSettle();
       expect(listFinder, findsNothing);
     });
 
-    testWidgets('Searchfield should find suggestion ignoring diacritics',
+    testWidgets('Searchfield should find suggestion when typed reversed if we add custom comparator for it',
         (WidgetTester tester) async {
       final controller = TextEditingController();
       await tester.pumpWidget(_boilerplate(
           child: SearchField(
         key: const Key('searchfield'),
-        ignoreDiacritics: true,
-        suggestions: ['ABC', 'DÉF', 'GHI', 'JKL']
+        comparator: (inputText, suggestionKey) => suggestionKey.contains(inputText.split('').reversed.join()),
+        suggestions: ['ABC', 'DEF', 'GHI', 'JKL']
             .map((e) => SearchFieldListItem<String>(e))
             .toList(),
         controller: controller,
@@ -597,15 +589,15 @@ void main() {
       expect(textField, findsOneWidget);
       expect(listFinder, findsNothing);
       await tester.tap(textField);
-      await tester.enterText(textField, 'Á');
+      await tester.enterText(textField, 'AB');
       await tester.pumpAndSettle();
       expect(listFinder, findsOneWidget);
       expect(find.text('ABC'), findsOneWidget);
       expect(listFinder.evaluate().length, 1);
-      await tester.enterText(textField, 'DE');
+      await tester.enterText(textField, 'BA');
       await tester.pumpAndSettle();
       expect(listFinder, findsOneWidget);
-      expect(find.text('DÉF'), findsOneWidget);
+      expect(find.text('ABC'), findsOneWidget);
       expect(listFinder.evaluate().length, 1);
     });
 }


### PR DESCRIPTION
If this option is set to true, using diacritics as á, é... is equivalent to not using it, no matter if diacritics is in suggestions or in query. With this option, if we have "café" in suggestion list and we search for "cafe", it will show "café", and viceversa, if we have "cafe" in suggestions and we try to find "café", "cafe" will be shown.

This is very useful in latin languages, because most of users when they are typing in a phone, sometimes forget about using proper diacritics symbols, because is faster not typing it, so this can support use from that users.