### PR TITLE
Bug fix: onTap doesn't work in flutter web v3.7

### DIFF
--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -453,7 +453,7 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
               physics: snapshot.data!.length == 1
                   ? NeverScrollableScrollPhysics()
                   : ScrollPhysics(),
-              itemBuilder: (context, index) => InkWell(
+              itemBuilder: (context, index) => TextFieldTapRegion(child: InkWell(
                 onTap: () {
                   searchController!.text = snapshot.data![index]!.searchKey;
                   searchController!.selection = TextSelection.fromPosition(
@@ -507,7 +507,7 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
                         style: widget.suggestionStyle,
                       ),
                 ),
-              ),
+              )),
             ),
           );
         }


### PR DESCRIPTION
In new version flutter 3.7, the onTap propertie of InkWell for flutter web is never called, this fix the problem just wrapping the InkWell widget in a TextFieldTapRegion widget.

Fix the issue #70  