### PR TITLE
(feat) added vertical padding to total height in _suggestion_builder

### DIFF
--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -415,12 +415,17 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
         } else if (snapshot.data!.isEmpty) {
           return widget.emptyWidget;
         } else {
+          final paddingHeight = widget.suggestionsDecoration != null
+              ? widget.suggestionsDecoration!.padding.vertical
+              : 0;
           if (snapshot.data!.length > widget.maxSuggestionsInViewPort) {
-            _totalHeight = widget.itemHeight * widget.maxSuggestionsInViewPort;
+            _totalHeight = widget.itemHeight * widget.maxSuggestionsInViewPort +
+                paddingHeight;
           } else if (snapshot.data!.length == 1) {
-            _totalHeight = widget.itemHeight;
+            _totalHeight = widget.itemHeight + paddingHeight;
           } else {
-            _totalHeight = snapshot.data!.length * widget.itemHeight;
+            _totalHeight =
+                snapshot.data!.length * widget.itemHeight + paddingHeight;
           }
           final onSurfaceColor = Theme.of(context).colorScheme.onSurface;
 

--- a/test/searchfield_test.dart
+++ b/test/searchfield_test.dart
@@ -477,6 +477,204 @@ void main() {
       expect(find.byType(RawScrollbar), findsOneWidget);
     });
   });
+
+  group(
+      'AnimatedContainer should be render with BoxConstraints height must be include itemHeight, '
+      'amount of suggestions and SuggestionDecoration EdgeInsets different cases',
+      () {
+    testWidgets(
+        'AnimatedContainer should be render with BoxConstraints height must be include itemHeight'
+        ' and amount of suggestions and without vertical padding without SuggestionDecoration EdgeInsets',
+        (WidgetTester tester) async {
+      const suggestions = ['ABC', 'DEF', 'GHI'];
+      const double itemHeight = 40;
+      final animatedContainerHeight = suggestions.length * itemHeight;
+      final expectedBoxConstraintsResult = BoxConstraints(
+        minHeight: animatedContainerHeight,
+        maxHeight: animatedContainerHeight,
+      );
+
+      await tester.pumpWidget(_boilerplate(
+          child: SearchField(
+        itemHeight: itemHeight,
+        key: const Key('searchfield'),
+        suggestions: suggestions.map(SearchFieldListItem<String>.new).toList(),
+        suggestionState: Suggestion.expand,
+      )));
+
+      final textField = find.byType(TextFormField);
+      expect(textField, findsOneWidget);
+      await tester.tap(textField);
+      await tester.enterText(textField, '');
+      await tester.pumpAndSettle();
+      final animatedContainer = find.byType(AnimatedContainer);
+      final BoxConstraints? animatedContainerConstraints =
+          tester.widget<AnimatedContainer>(animatedContainer).constraints;
+      expect(find.byType(ListView), findsOneWidget);
+      expect(animatedContainer, findsOneWidget);
+      expect(animatedContainerConstraints, expectedBoxConstraintsResult);
+    });
+
+    testWidgets(
+        'AnimatedContainer should be render with BoxConstraints height must be include itemHeight'
+        ' and amount of suggestions with EdgeInsets.only without left and right property',
+        (WidgetTester tester) async {
+      const suggestions = ['ABC', 'DEF', 'GHI'];
+      const double itemHeight = 40;
+      const suggestionDecorationPadding =
+          EdgeInsets.only(left: 0, right: 0, top: 5, bottom: 7);
+      final animatedContainerHeight = suggestions.length * itemHeight +
+          suggestionDecorationPadding.top +
+          suggestionDecorationPadding.bottom;
+      final expectedBoxConstraintsResult = BoxConstraints(
+        minHeight: animatedContainerHeight,
+        maxHeight: animatedContainerHeight,
+      );
+
+      await tester.pumpWidget(_boilerplate(
+          child: SearchField(
+        itemHeight: itemHeight,
+        key: const Key('searchfield'),
+        suggestions: suggestions.map(SearchFieldListItem<String>.new).toList(),
+        suggestionState: Suggestion.expand,
+        suggestionsDecoration: SuggestionDecoration(
+          padding: suggestionDecorationPadding,
+        ),
+      )));
+
+      final textField = find.byType(TextFormField);
+      expect(textField, findsOneWidget);
+      await tester.tap(textField);
+      await tester.enterText(textField, '');
+      await tester.pumpAndSettle();
+      final animatedContainer = find.byType(AnimatedContainer);
+      final BoxConstraints? animatedContainerConstraints =
+          tester.widget<AnimatedContainer>(animatedContainer).constraints;
+      expect(find.byType(ListView), findsOneWidget);
+      expect(animatedContainer, findsOneWidget);
+      expect(animatedContainerConstraints, expectedBoxConstraintsResult);
+    });
+
+    testWidgets(
+        'AnimatedContainer should be render with BoxConstraints height must be include itemHeight'
+        ' and amount of suggestions with EdgeInsets.only with all property but left and right should be ignored ',
+        (WidgetTester tester) async {
+      const suggestions = ['ABC', 'DEF', 'GHI'];
+      const double itemHeight = 40;
+      const suggestionDecorationPadding =
+          EdgeInsets.only(left: 10, right: 10, top: 5, bottom: 7);
+      final animatedContainerHeight = suggestions.length * itemHeight +
+          suggestionDecorationPadding.top +
+          suggestionDecorationPadding.bottom;
+      final expectedBoxConstraintsResult = BoxConstraints(
+        minHeight: animatedContainerHeight,
+        maxHeight: animatedContainerHeight,
+      );
+
+      await tester.pumpWidget(_boilerplate(
+          child: SearchField(
+        itemHeight: itemHeight,
+        key: const Key('searchfield'),
+        suggestions: suggestions.map(SearchFieldListItem<String>.new).toList(),
+        suggestionState: Suggestion.expand,
+        suggestionsDecoration: SuggestionDecoration(
+          padding: suggestionDecorationPadding,
+        ),
+      )));
+
+      final textField = find.byType(TextFormField);
+      expect(textField, findsOneWidget);
+      await tester.tap(textField);
+      await tester.enterText(textField, '');
+      await tester.pumpAndSettle();
+      final animatedContainer = find.byType(AnimatedContainer);
+      final BoxConstraints? animatedContainerConstraints =
+          tester.widget<AnimatedContainer>(animatedContainer).constraints;
+      expect(find.byType(ListView), findsOneWidget);
+      expect(animatedContainer, findsOneWidget);
+      expect(animatedContainerConstraints, expectedBoxConstraintsResult);
+    });
+
+    testWidgets(
+        'AnimatedContainer should be render with BoxConstraints height must be include itemHeight'
+        ' and amount of suggestions with EdgeInsets.symmetric with all property but horizontal should be ignored',
+        (WidgetTester tester) async {
+      const suggestions = ['ABC', 'DEF', 'GHI'];
+      const double itemHeight = 40;
+      const suggestionDecorationPadding =
+          EdgeInsets.symmetric(vertical: 20, horizontal: 20);
+      final animatedContainerHeight = suggestions.length * itemHeight +
+          suggestionDecorationPadding.top +
+          suggestionDecorationPadding.bottom;
+      final expectedBoxConstraintsResult = BoxConstraints(
+        minHeight: animatedContainerHeight,
+        maxHeight: animatedContainerHeight,
+      );
+
+      await tester.pumpWidget(_boilerplate(
+          child: SearchField(
+        itemHeight: itemHeight,
+        key: const Key('searchfield'),
+        suggestions: suggestions.map(SearchFieldListItem<String>.new).toList(),
+        suggestionState: Suggestion.expand,
+        suggestionsDecoration: SuggestionDecoration(
+          padding: suggestionDecorationPadding,
+        ),
+      )));
+
+      final textField = find.byType(TextFormField);
+      expect(textField, findsOneWidget);
+      await tester.tap(textField);
+      await tester.enterText(textField, '');
+      await tester.pumpAndSettle();
+      final animatedContainer = find.byType(AnimatedContainer);
+      final BoxConstraints? animatedContainerConstraints =
+          tester.widget<AnimatedContainer>(animatedContainer).constraints;
+      expect(find.byType(ListView), findsOneWidget);
+      expect(animatedContainer, findsOneWidget);
+      expect(animatedContainerConstraints, expectedBoxConstraintsResult);
+    });
+
+    testWidgets(
+        'AnimatedContainer should be render with BoxConstraints height must be include itemHeight'
+        ' and amount of suggestions with EdgeInsets.all ',
+        (WidgetTester tester) async {
+      const suggestions = ['ABC', 'DEF', 'GHI'];
+      const double itemHeight = 40;
+      const suggestionDecorationPadding = EdgeInsets.all(20);
+      final animatedContainerHeight = suggestions.length * itemHeight +
+          suggestionDecorationPadding.top +
+          suggestionDecorationPadding.bottom;
+      final expectedBoxConstraintsResult = BoxConstraints(
+        minHeight: animatedContainerHeight,
+        maxHeight: animatedContainerHeight,
+      );
+
+      await tester.pumpWidget(_boilerplate(
+          child: SearchField(
+        itemHeight: itemHeight,
+        key: const Key('searchfield'),
+        suggestions: suggestions.map(SearchFieldListItem<String>.new).toList(),
+        suggestionState: Suggestion.expand,
+        suggestionsDecoration: SuggestionDecoration(
+          padding: suggestionDecorationPadding,
+        ),
+      )));
+
+      final textField = find.byType(TextFormField);
+      expect(textField, findsOneWidget);
+      await tester.tap(textField);
+      await tester.enterText(textField, '');
+      await tester.pumpAndSettle();
+      final animatedContainer = find.byType(AnimatedContainer);
+      final BoxConstraints? animatedContainerConstraints =
+          tester.widget<AnimatedContainer>(animatedContainer).constraints;
+      expect(find.byType(ListView), findsOneWidget);
+      expect(animatedContainer, findsOneWidget);
+      expect(animatedContainerConstraints, expectedBoxConstraintsResult);
+    });
+  });
+
   group('Suggestions should respect suggestionDirection', () {
     testWidgets(
         'suggestions should respect suggestionDirection: SuggestionDirection.up',


### PR DESCRIPTION
Dear @maheshmnj,

I trust this email finds you well.

Firstly, I would like to extend my gratitude to you for the recent improvements you've made to the SearchField package. The addition of padding has greatly enhanced user interaction and brought a superior aesthetic quality to the feature. Your attention to detail and dedication to providing valuable contributions are both commendable and appreciated.

I wanted to bring to your attention that I have further refined the package by adding vertical padding to the total height in the suggestion_builder. I am attaching two videos that demonstrate the before and after effects of this enhancement for your reference.

### Before

https://github.com/maheshmnj/searchfield/assets/66751960/98b748af-9e8d-449f-ae87-b8692da2ce41

### After

https://github.com/maheshmnj/searchfield/assets/66751960/9940823c-8844-495a-99d9-bc30ec22f0ed

However, during my testing process, I noticed an issue related to animation jumping. While the overall functionality is not hindered, the jumping does have an adverse impact on user experience, given that fluid animation contributes significantly to a user-friendly interface.

Your expertise and insights would be of great help in resolving this issue. Could you please assist me in debugging this problem to ensure smoother animations? Your assistance in this matter would be greatly appreciated.

Looking forward to your positive response.

Best Regards,

Andrii