### PR TITLE
Feat add suggestion alignment

### DIFF
--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -203,6 +203,10 @@ class SearchField<T> extends StatefulWidget {
   /// Keyboard Type for SearchField
   final TextInputType? inputType;
 
+  /// Alignment for the suggestion list
+  /// defaults to [Alignment.centerLeft]
+  final AlignmentGeometry? suggestionsAlignment;
+
   /// `validator` for the [SearchField]
   /// to make use of this validator, The
   /// SearchField widget needs to be wrapped in a Form
@@ -298,6 +302,7 @@ class SearchField<T> extends StatefulWidget {
       this.textCapitalization = TextCapitalization.none,
       this.textInputAction,
       this.validator,
+      this.suggestionsAlignment,
       @Deprecated('use `onSearchTextChanged` instead.') this.comparator})
       : assert(
             (initialValue != null &&
@@ -460,9 +465,10 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
                 }
               },
               child: Container(
+                
                 height: widget.itemHeight,
                 width: double.infinity,
-                alignment: Alignment.centerLeft,
+                alignment: widget.suggestionsAlignment??Alignment.centerLeft,
                 decoration: widget.suggestionItemDecoration?.copyWith(
                       border: widget.suggestionItemDecoration?.border ??
                           Border(
@@ -485,6 +491,7 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
                 child: snapshot.data![index]!.child ??
                     Text(
                       snapshot.data![index]!.searchKey,
+                      key: Key('$index-suggestion'),
                       style: widget.suggestionStyle,
                     ),
               ),
@@ -496,7 +503,7 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
                 ? Duration.zero
                 : Duration(milliseconds: 300),
             height: _totalHeight,
-            alignment: Alignment.centerLeft,
+            alignment:widget.suggestionsAlignment?? Alignment.centerLeft,
             decoration: widget.suggestionsDecoration ??
                 BoxDecoration(
                   color: Theme.of(context).colorScheme.surface,

--- a/test/searchfield_test.dart
+++ b/test/searchfield_test.dart
@@ -489,6 +489,69 @@ void main() {
       expect(find.byType(RawScrollbar), findsOneWidget);
     });
   });
+
+  group('Suggestions should respect suggestionsAlignment', () {
+    testWidgets('suggestions should be aligned to left by default',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(_boilerplate(
+          child: SearchField(
+        key: const Key('searchfield'),
+        itemHeight: 100,
+        suggestions:
+            ['ABC'].map(SearchFieldListItem<String>.new).toList(),
+      )));
+      final listFinder = find.byType(ListView);
+      expect(find.byType(TextFormField), findsOneWidget);
+      expect(listFinder, findsNothing);
+      await tester.tap(find.byType(TextFormField));
+      await tester.enterText(find.byType(TextFormField), '');
+      await tester.pumpAndSettle();
+      expect(listFinder, findsOneWidget);
+      final suggestionFinder = find.byKey(Key('0-suggestion'));
+      final suggestionsRenderBox = tester.renderObject(suggestionFinder) as RenderBox;
+      final suggestionOffset = suggestionsRenderBox.localToGlobal(Offset.zero);
+      final suggestionPredictedOffset = Offset(0.0,643.0);
+      expect(suggestionOffset, equals(suggestionPredictedOffset));
+      await tester.tap(find.byType(TextFormField));
+      await tester.enterText(find.byType(TextFormField), 'ABC');
+      await tester.pumpAndSettle();
+      expect(listFinder.evaluate().length, 1);
+      final suggestionOffsetNew =
+          suggestionsRenderBox.localToGlobal(Offset.zero);
+      expect(suggestionOffsetNew, equals(suggestionPredictedOffset));
+
+    });
+    testWidgets('suggestions should be aligned to right',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(_boilerplate(
+          child: SearchField(
+        key: const Key('searchfield'),
+        itemHeight: 100,
+        suggestions:
+            ['ABC'].map(SearchFieldListItem<String>.new).toList(),
+        suggestionsAlignment: Alignment.centerRight,
+      )));
+      final listFinder = find.byType(ListView);
+      expect(find.byType(TextFormField), findsOneWidget);
+      expect(listFinder, findsNothing);
+      await tester.tap(find.byType(TextFormField));
+      await tester.enterText(find.byType(TextFormField), '');
+      await tester.pumpAndSettle();
+      expect(listFinder, findsOneWidget);
+      final suggestionFinder = find.byKey(Key('0-suggestion'));
+      final suggestionsRenderBox = tester.renderObject(suggestionFinder) as RenderBox;
+      final suggestionOffset = suggestionsRenderBox.localToGlobal(Offset.zero);
+      expect(suggestionOffset, equals(Offset(758.0, 643.0)));
+      await tester.tap(find.byType(TextFormField));
+      await tester.enterText(find.byType(TextFormField), 'ABC');
+      await tester.pumpAndSettle();
+      expect(listFinder.evaluate().length, 1);
+      final suggestionOffsetNew =
+          suggestionsRenderBox.localToGlobal(Offset.zero);
+      expect(suggestionOffsetNew, equals(Offset(758.0, 643.0)));
+
+   });
+  });
   group('Suggestions should respect suggestionDirection', () {
     testWidgets(
         'suggestions should respect suggestionDirection: SuggestionDirection.up',

--- a/test/searchfield_test.dart
+++ b/test/searchfield_test.dart
@@ -537,18 +537,20 @@ void main() {
       await tester.tap(find.byType(TextFormField));
       await tester.enterText(find.byType(TextFormField), '');
       await tester.pumpAndSettle();
+      final suggestionPredictedOffset = Offset(758.0, 643.0);
       expect(listFinder, findsOneWidget);
       final suggestionFinder = find.byKey(Key('0-suggestion'));
       final suggestionsRenderBox = tester.renderObject(suggestionFinder) as RenderBox;
       final suggestionOffset = suggestionsRenderBox.localToGlobal(Offset.zero);
-      expect(suggestionOffset, equals(Offset(758.0, 643.0)));
+      
+      expect(suggestionOffset, equals(suggestionPredictedOffset));
       await tester.tap(find.byType(TextFormField));
       await tester.enterText(find.byType(TextFormField), 'ABC');
       await tester.pumpAndSettle();
       expect(listFinder.evaluate().length, 1);
       final suggestionOffsetNew =
           suggestionsRenderBox.localToGlobal(Offset.zero);
-      expect(suggestionOffsetNew, equals(Offset(758.0, 643.0)));
+      expect(suggestionOffsetNew, equals(suggestionPredictedOffset));
 
    });
   });


### PR DESCRIPTION
*need to align RTL texts from right to left currently the suggestion is sticked to the left side

Describe the solution you'd like
Add Alignment argument to the searchfield widget

Describe alternatives you've considered

Additional context
Ill add a PR for the solution*

*#90*


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing using `flutter test`

If you need help, consider pinging the maintainer @maheshmnj

<!-- Links -->
[Contributor Guide]: https://github.com/maheshmnj/searchfield/blob/master/CONTRIBUTING.md