### PR TITLE
Add Max Length and Text Counter Builder

### DIFF
--- a/lib/src/searchfield.dart
+++ b/lib/src/searchfield.dart
@@ -118,6 +118,16 @@ class SearchField<T> extends StatefulWidget {
   /// Defines whether to show the searchfield as readOnly
   final bool readOnly;
 
+  /// Defines character limit for searchfield
+  final int? maxLength;
+
+  /// Defines mechanisms for enforcing maximum length limits
+  final MaxLengthEnforcement? maxLengthEnforcement;
+
+  /// If buildCounter returns null, then no counter and no Semantics widget will
+  /// be created at all.
+  final InputCounterWidgetBuilder? buildCounter;
+
   /// Used to enable/disable this form field auto validation and update its error text.
 
   /// If AutovalidateMode.onUserInteraction, this FormField will only auto-validate after its
@@ -324,6 +334,9 @@ class SearchField<T> extends StatefulWidget {
     this.itemHeight = 35.0,
     this.marginColor,
     this.maxSuggestionsInViewPort = 5,
+    this.maxLength,
+    this.maxLengthEnforcement,
+    this.buildCounter,
     this.readOnly = false,
     this.onSearchTextChanged,
     this.onSaved,
@@ -844,6 +857,9 @@ class _SearchFieldState<T> extends State<SearchField<T>> {
               onSaved: (x) {
                 if (widget.onSaved != null) widget.onSaved!(x);
               },
+              maxLength: widget.maxLength,
+              maxLengthEnforcement: widget.maxLengthEnforcement,
+              buildCounter: widget.buildCounter,
               inputFormatters: widget.inputFormatters,
               controller: searchController,
               focusNode: _searchFocus,

--- a/test/searchfield_test.dart
+++ b/test/searchfield_test.dart
@@ -1403,6 +1403,30 @@ void main() {
     // expect(scrollbarWidget.controller!.offset, 100.0);
   });
 
+  testWidgets('Searchfield should limit the character count',
+          (widgetTester) async {
+        final controller = TextEditingController();
+        final countries = data.map(Country.fromMap).toList();
+        final maxLength = 3;
+        await widgetTester.pumpWidget(_boilerplate(
+            child: SearchField(
+              controller: controller,
+              suggestions:
+              countries.map((e) => SearchFieldListItem<Country>(e.name)).toList(),
+              suggestionState: Suggestion.expand,
+              maxLength: maxLength,
+              maxLengthEnforcement: MaxLengthEnforcement.enforced,
+            )));
+
+        final textField = find.byType(TextFormField);
+        expect(textField, findsOneWidget);
+        await widgetTester.tap(textField);
+        await widgetTester.pumpAndSettle();
+        await widgetTester.enterText(textField, 'abc');
+        expect(find.text('abc'), findsOneWidget);
+        expect(find.text('abcd'), findsNothing);
+      });
+
   // testWidgets(
   //     'Selecting suggestion with keyboard should return the searchKey in `onSuggestionTapped`',
   //     (widgetTester) async {


### PR DESCRIPTION
The code has been updated to allow setting the maximum character limit for the SearchField widget in Dart. In addition to defining the maxLength, you can also specify how to enforce the length limit and create a widget for displaying the current length/limit information.

This will add feature to allow adding maxLength and related changes (Enforcement and Counter)

This will fix this issue:

[Add Max Length and Option to disable counter for TextFormField #145](https://github.com/maheshmnj/searchfield/issues/145)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing using `flutter test`

If you need help, consider pinging the maintainer @maheshmnj

<!-- Links -->
[Contributor Guide]: https://github.com/maheshmnj/searchfield/blob/master/CONTRIBUTING.md