### PR TITLE
fix(input_decoration): add missing visualDensity and semanticsService parameters for Flutter 3.35.1 compatibility

### DIFF
--- a/lib/src/input_decoration.dart
+++ b/lib/src/input_decoration.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 
 class SearchInputDecoration extends InputDecoration {
   /// text capitalization defaults to [TextCapitalization.none]
@@ -130,6 +131,7 @@ class SearchInputDecoration extends InputDecoration {
     super.errorMaxLines,
     super.errorStyle,
     super.suffixIconConstraints,
+    super.visualDensity,
   });
 
   @override
@@ -200,8 +202,11 @@ class SearchInputDecoration extends InputDecoration {
     TextStyle? suffixStyle,
     String? suffixText,
     bool? maintainHintSize,
+    VisualDensity? visualDensity,
+    SemanticsService? semanticsService,
   }) {
     return SearchInputDecoration(
+      key: key ?? this.key,
       maintainHintHeight: maintainHintHeight ?? this.maintainHintHeight,
       maintainHintSize: maintainHintSize ?? this.maintainHintSize,
       cursorColor: cursorColor ?? this.cursorColor,
@@ -271,6 +276,7 @@ class SearchInputDecoration extends InputDecoration {
       suffixIconColor: suffixIconColor ?? this.suffixIconColor,
       suffixStyle: suffixStyle ?? this.suffixStyle,
       suffixText: suffixText ?? this.suffixText,
+      visualDensity: visualDensity ?? this.visualDensity,
     );
   }
 }


### PR DESCRIPTION
This pull request addresses a compatibility issue between the `searchfield` package and Flutter 3.35.1. Specifically, the `SearchInputDecoration` class's `copyWith` method includes a `semanticsService` parameter, which conflicts with the overridden `copyWith` method in Flutter's `InputDecoration` class.

*List which issues are fixed by this PR. You must list at least one issue.*
#248 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing using `flutter test`

@maheshj01 — please take a look when you get a chance.

<!-- Links -->
[Contributor Guide]: https://github.com/maheshj01/searchfield/blob/master/CONTRIBUTING.md